### PR TITLE
Documentation and Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,10 @@
 *.glob
 *.vo
 *.vok
+*.vos
 *.aux
-# Maybe we do want Makefile.coq and Makefile.coq.conf?
+# Maybe we do want the machine generated Makefiles?
 # I ignore them because they are machine generated.
 Makefile.*
+.Makefile.coq.d
+CoqMakefile.conf

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ This folder contains all the artifacts for the x86-to-CHERI translation project.
 
 ## Artifacts
 
-* sample.c --- several simple functions that operate only on registers, note that even with the `-O0` flag to disable optimization the CompCert compiler optimizes away assignments and operations that result in statically determined values. E.g. `int x = 4; int y = 2; return x + y` is optimized to `return 6`.
+* sample.c --- several simple functions that operate only on registers, note that even with the `-O0` flag to disable optimization the CompCert compiler optimizes away assignments and operations that result in easily determined values. E.g. `int x = 4; int y = 2; return x + y` is optimized to `return 6`, but the for-loop with a static effect is not optimized.
 
 ## Build Instructions
+
+### Building Sample Binaries
 
 1. Build [SECOMP](https://github.com/secure-compilation/SECOMP)'s CHERI RiscV enabled CompCert fork for rv64-linux. You will need the riscv64 extension to gcc and to use Coq's Flocq and MenhirLib (otherwise you'll get inconsistent assumptions when importing it and CompCert simultaneously).
 
@@ -38,17 +40,23 @@ This folder contains all the artifacts for the x86-to-CHERI translation project.
 
 5. Run `./build.sh`.
 
-6. Install CompCert through opam. This is redundant with 3 and 4, ideally these instructions will explain how to use the opam CompCert to compile the C code to x86_64.
-
-    ```shell
-    opam install coq-compcert
-    ```
-
 This should create the following files:
 
 * samplerv.{o,s}
 * sample.cap_asm    # cap is short for 'capability'
 * samplex64.{o,s}
+
+### Building Coq Files
+
+1. Install CompCert through opam. This is redundant with steps 3 and 4 above, ideally these instructions will explain how to use the opam CompCert to compile the C code to x86_64.
+
+    ```shell
+    opam install coq-compcert
+    ```
+
+2. Execute `coq_makefile`.
+
+3. Execute `make`.
 
 ## Resources
 

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,3 +1,4 @@
+-R . Project
 -Q /home/ixb140230/git_clones/SECOMP secomp
 
 absint_setup.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,6 +1,4 @@
--R . Project
 -Q /home/ixb140230/git_clones/SECOMP secomp
-# -Q /home/ixb140230/.opam/secomp/lib/coq/user-contrib/compcert compcert
 
 absint_setup.v
 whilelang/Sign.v

--- a/whilelang/Sign.v
+++ b/whilelang/Sign.v
@@ -15,6 +15,7 @@ Local Open Scope string_scope.
 Local Open Scope error_monad_scope.
 
 Inductive sign : Type :=
+| Bot : sign
 | Pos : sign
 | Neg : sign
 | Zero : sign 
@@ -22,6 +23,7 @@ Inductive sign : Type :=
 
 Definition sign_add (s1 s2 : sign) : sign :=
 match s1, s2 with 
+| Bot, _ | _, Bot => Bot
 | Pos, Pos => Pos
 | Neg, Neg => Neg 
 | Pos, Neg => Top
@@ -33,6 +35,7 @@ end.
 
 Definition neg_sign (s1 : sign) : sign :=
 match s1 with 
+| Bot => Bot
 | Pos => Neg 
 | Neg => Pos
 | Zero => Zero
@@ -41,6 +44,7 @@ end.
 
 Definition sign_minus (s1 s2 : sign) : sign :=
 match s1, s2 with
+| Bot, _ | _, Bot => Bot
 | Pos, Pos => Top
 | Pos, Zero => Pos
 | Pos, Neg => Top
@@ -74,6 +78,7 @@ Definition sign_or (s1 s2 : sign) : sign := Top.
 
 Definition eq_sign (s1 s2 : sign) : bool :=
 match s1, s2 with 
+| Bot, Bot => true
 | Neg, Neg => true 
 | Pos, Pos => true 
 | Zero, Zero => true 
@@ -83,6 +88,7 @@ end.
 
 Definition join_sign (s1 s2 : sign) : sign :=
 match s1, s2 with 
+| Bot, s | s, Bot => s
 | Pos, Pos => Pos
 | Neg, Neg => Neg
 | Zero, Zero => Zero
@@ -91,16 +97,18 @@ end.
 
 Definition intersect_sign (s1 s2 : sign) : sign :=
 match s1, s2 with
+| Bot, x | x, Bot => Bot
 | Top, x | x, Top => x
 | Pos, Pos => Pos
 | Neg, Neg => Neg
 | Zero, Zero => Zero
-| _, _ => (* they disagree *) Top
+| _, _ => (* they disagree *) Bot
 end.
 
 (* If the new value equals the old one, keep it; otherwise, go to Top. *)
 Definition widen_sign (old new : sign) : sign :=
 match old, new with
+| Bot, Bot => Bot
 | Pos, Pos => Pos
 | Neg, Neg => Neg
 | Zero, Zero => Zero
@@ -110,6 +118,7 @@ end.
 (* If we overshot to Top but the new value is more precise, accept it. *)
 Definition sign_narrow (old new : sign) : sign :=
 match old, new with
+| Top, Bot => Bot
 | Top, Pos => Pos
 | Top, Neg => Neg
 | Top, Zero => Zero
@@ -127,6 +136,7 @@ else if Integers.Int64.lt Integers.Int64.zero i
 
 Definition to_con (s : sign) : int64 -> Prop :=
 match s with 
+| Bot => fun i => False
 | Pos => fun i => Integers.Int64.lt Integers.Int64.zero i
 | Neg => fun i => Integers.Int64.lt i Integers.Int64.zero
 | Zero => fun i => Integers.Int64.eq i Integers.Int64.zero


### PR DESCRIPTION
Fix: The intersect_sign function was broken---it said the intersection of e.g. Neg and Pos is Top, but it should be the empty set. This isn't a problem for our language because it doesn't have "guards" which prune the set of possible executions, but it doesn't do well for an example to be broken.

Also documented some phenomena we observed in the examples that look broken, but just highlight unintuitive behavior of abstract interpretation.